### PR TITLE
Add error message for url-metadata broken

### DIFF
--- a/src/controllers/posts.controller.js
+++ b/src/controllers/posts.controller.js
@@ -44,6 +44,11 @@ export async function getPosts(req, res) {
         },
         function (error) {
           console.log(error, "lib url-metadata");
+          posts.rows[i].metadata = {
+            image: 'https://ps.w.org/broken-link-checker/assets/icon-256x256.png',
+            title: 'Erro 400',
+            description: 'Erro na renderização do link',
+          };
         }
       );
       const user = await userRepositories.getUserById(posts.rows[i].userId);


### PR DESCRIPTION
- Adicionada linhas 47 a 51 na função getPost para lidar com erros da lib url-metadata sem quebrar o front